### PR TITLE
fix: Drop email_template foreign key

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,8 @@ Documentation is at [docs/guide/README.md](docs/guide/README.md).
 
 [![Build Status](https://travis-ci.org/yiimaker/yii2-email-templates.svg?branch=master)](https://travis-ci.org/yiimaker/yii2-email-templates)
 [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/yiimaker/yii2-email-templates/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/yiimaker/yii2-email-templates/?branch=master)
-[![Total Downloads](https://poser.pugx.org/yiimaker/yii2-email-templates/downloads)](https://packagist.org/packages/yiimaker/yii2-email-templates)
-[![Latest Stable Version](https://poser.pugx.org/yiimaker/yii2-email-templates/v/stable)](CHANGELOG.md)
-[![Latest Unstable Version](https://poser.pugx.org/yiimaker/yii2-email-templates/v/unstable)](CHANGELOG.md)
+[![Total Downloads](https://img.shields.io/packagist/dt/yiimaker/yii2-email-templates.svg)](https://packagist.org/packages/yiimaker/yii2-email-templates)
+[![Latest Stable Version](https://img.shields.io/packagist/v/yiimaker/yii2-email-templates.svg)](https://packagist.org/packages/yiimaker/yii2-email-templates)
 
 Installation
 ------------
@@ -127,7 +126,7 @@ For information about contributing please read [CONTRIBUTING.md](CONTRIBUTING.md
 
 License
 -------
-[![License](https://poser.pugx.org/yiimaker/yii2-email-templates/license)](LICENSE)
+[![License](https://img.shields.io/github/license/yiimaker/yii2-email-templates.svg)](LICENSE)
 
 This project is released under the terms of the BSD-3-Clause [license](LICENSE).
 

--- a/src/migrations/m171119_140800_create_email_template_entities.php
+++ b/src/migrations/m171119_140800_create_email_template_entities.php
@@ -95,7 +95,7 @@ class m171119_140800_create_email_template_entities extends Migration
      */
     public function safeDown()
     {
-        $this->dropForeignKey('fk-email_template_translation-email_template', $this->primaryTableName);
+        $this->dropForeignKey('fk-email_template_translation-email_template', $this->translationTableName);
 
         $this->dropIndex('idx-email_template_translation-language', $this->translationTableName);
         $this->dropIndex('idx-email_template_translation-templateId', $this->translationTableName);


### PR DESCRIPTION
Drop from $translationTableName instead of $primaryTableName.
Fix: allow migration/redo.
